### PR TITLE
[fix] Change the way how index of pressed section is obtained

### DIFF
--- a/components/SectionList.js
+++ b/components/SectionList.js
@@ -58,11 +58,11 @@ export default class SectionList extends Component {
     //})
     const targetY = ev.pageY;
     const { y, width, height } = this.measure;
-    if(!y || targetY < y){
+    const index = (Math.floor(ev.locationY / height));
+    if (index >= this.props.sections.length) {
       return;
     }
-    let index = Math.floor((targetY - y) / height);
-    index = Math.min(index, this.props.sections.length - 1);
+
     if (this.lastSelectedIndex !== index && this.props.data[this.props.sections[index]].length) {
       this.lastSelectedIndex = index;
       this.onSectionSelect(this.props.sections[index], true);
@@ -196,7 +196,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     backgroundColor: 'transparent',
     alignItems:'flex-end',
-    justifyContent:'center',
+    justifyContent:'flex-start',
     right: 5,
     top: 0,
     bottom: 0


### PR DESCRIPTION
The list was moved to the top to simplify way how we count the index. The main
reason for this step is that current version is no longer working properly with RN 0.43. Unpatched version works fine with RN 0.33