### PR TITLE
Avoid access attribute on undefined

### DIFF
--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -166,7 +166,7 @@ export default class SelectableSectionsListView extends Component {
     index = parseInt(index, 10);
 
     const isFirst = index === 0;
-    const isLast = this.sectionItemCount[sectionId]-1 === index;
+    var isLast = this.sectionItemCount && this.sectionItemCount[sectionId]-1 === index;
 
     const props = {
       isFirst,

--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -166,7 +166,7 @@ export default class SelectableSectionsListView extends Component {
     index = parseInt(index, 10);
 
     const isFirst = index === 0;
-    var isLast = this.sectionItemCount && this.sectionItemCount[sectionId]-1 === index;
+    const isLast = this.sectionItemCount && this.sectionItemCount[sectionId]-1 === index;
 
     const props = {
       isFirst,


### PR DESCRIPTION
- This is a fix to avoid access an attribute of an object when the list is loaded async